### PR TITLE
docs: update README and docs for v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ LM Studio   →   lmcode agent   →   your codebase
 - **OpenAPI → MCP** — point lmcode at any OpenAPI spec and the endpoints become agent tools automatically (powered by [FastMCP](https://github.com/jlowin/fastmcp))
 - **Plugin system** — extend lmcode with plugins via entry points (pluggy-based)
 - **LMCODE.md** — per-repo memory file, like CLAUDE.md
+- **/compact** — summarises conversation history via the model, resets the chat, and injects the summary as context; shows a panel with summary preview and message count saved
+- **/tokens** — displays session-wide prompt (↑) and generated (↓) token totals, plus a context arc line (`◔ 38%  (14.2k / 32k tok)`)
+- **/hide-model** — toggles the model name in the live prompt (`● lmcode (model) [ask] ›` vs `● lmcode [ask] ›`)
+- **Cycling tips** — tips below the thinking spinner rotate every 8 seconds through a shuffled list
+- **Context window indicator** — arc chars `○◔◑◕●` with percentage shown in `/status` and `/tokens`; one-time warning at 80 % usage suggesting `/compact`
+- **Spinner keepalive** — asyncio keepalive task refreshes the spinner label every 100 ms during model prefill, preventing display freezes
+
+## Slash commands
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show all available slash commands |
+| `/status` | Show session stats, model info, and context window usage |
+| `/tokens` | Show session prompt (↑) and generated (↓) token totals with context arc |
+| `/compact` | Summarise history, reset chat, inject summary as context |
+| `/hide-model` | Toggle model name visibility in the live prompt |
+| `/verbose` | Toggle verbose tool-call output |
+| `/tips` | Toggle cycling tips below the thinking spinner |
+| `/stats` | Toggle per-turn stats line after each response |
+| `/tools` | List all registered tools |
 
 ---
 
@@ -212,7 +232,15 @@ uv run pytest
 - [ ] OpenAPI → MCP
 - [ ] Plugin system
 
-**v0.3 — Session viewer**
+**v0.3 — UX polish** ✓
+- [x] `/compact` — summarise history and reset chat (#31)
+- [x] `/tokens` — session token totals and context arc (#29)
+- [x] `/hide-model` — toggle model name in prompt (#36)
+- [x] Cycling tips — rotate every 8 s during thinking (#38)
+- [x] Context window indicator — arc + % in `/status` and `/tokens` (#41)
+- [x] Spinner keepalive — asyncio task keeps label fresh during prefill (#39)
+
+**v0.4 — Session viewer**
 - [ ] Textual TUI
 - [ ] Diff viewer
 - [ ] Session replay

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -72,6 +72,21 @@ user input
               → stream to terminal
 ```
 
+## Spinner keepalive pattern
+
+During model prefill the Python process is blocked inside the LM Studio SDK call, which prevents the Rich `Live` display from refreshing. To keep the spinner label visually active, `_run_turn` launches a short-lived `asyncio.create_task` keepalive coroutine before handing control to the model:
+
+```
+_run_turn()
+  ├── asyncio.create_task(_keepalive(live))   # polls every 100 ms, updates spinner label
+  ├── run model.act() in background thread    # blocks on GPU/prefill
+  └── task.cancel() once model returns        # stops keepalive when response arrives
+```
+
+The keepalive task owns **no shared state** — it only calls `live.update()` with a new label string derived from elapsed time. The main coroutine remains the single owner of the `Live` context; the task merely triggers redraws.
+
+This avoids the display freeze that occurs when the event loop is starved during long prefill windows (issue #39).
+
 ## Multi-agent pattern
 
 For complex tasks, an **Orchestrator** agent spawns **Worker** agents via `asyncio.gather`. Workers don't share state — they communicate only through their return values. LM Studio serializes GPU access at the server level, so workers run concurrently at the CPU/IO level but queue at the GPU.

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -65,6 +65,68 @@ lmcode mcp [SUBCOMMAND]
 
 > Not yet implemented — coming in `feat/mcp-support`.
 
+## Slash commands
+
+Slash commands are entered at the `lmcode chat` prompt and are processed client-side before the message is sent to the model.
+
+| Command | Description |
+|---------|-------------|
+| `/help` | List all available slash commands |
+| `/status` | Show session stats, model info, and context window usage arc |
+| `/tokens` | Show session-wide prompt (↑) and generated (↓) token totals with context arc |
+| `/compact` | Summarise conversation history via the model, reset the chat, and inject the summary as context |
+| `/hide-model` | Toggle the model name in the live prompt (`● lmcode (model) [ask] ›` vs `● lmcode [ask] ›`) |
+| `/verbose` | Toggle verbose tool-call output (tool name + preview after each call) |
+| `/tips` | Toggle cycling tips below the thinking spinner |
+| `/stats` | Toggle the per-turn stats line shown after each response |
+| `/tools` | List all tools currently registered with the agent |
+
+### /compact
+
+`/compact` is used to reclaim context window space without starting a completely new session. When invoked:
+
+1. A `bouncingBar` spinner is shown while the model generates a summary of the conversation so far.
+2. The chat history is cleared.
+3. The summary is injected as a system-level context message at the start of the new history.
+4. A panel is displayed with a preview of the summary and the number of messages that were compacted.
+
+### /tokens
+
+`/tokens` prints the running session totals for:
+
+- **Prompt tokens (↑)** — total tokens sent to the model across all turns.
+- **Generated tokens (↓)** — total tokens produced by the model across all turns.
+- **Context arc** — a visual indicator of context window fill, e.g. `◔ 38%  (14.2k / 32k tok)`.
+
+The same context arc is also shown in `/status`.
+
+### /hide-model
+
+`/hide-model` toggles whether the loaded model identifier is shown in the interactive prompt.
+
+- **Full prompt:** `● lmcode (qwen2.5-1.5b-instruct) [ask] ›`
+- **Compact prompt:** `● lmcode [ask] ›`
+
+This is useful when using a model with a long name that crowds the prompt line.
+
+## Cycling tips
+
+While the agent is thinking, a tip is shown below the spinner to help users discover features. Tips are drawn from a shuffled list and rotate automatically every 8 seconds. The list is reshuffled each time it is exhausted. Tips can be turned off with `/tips`.
+
+## Context window indicator
+
+The context window fill is represented with a five-step arc character sequence:
+
+```
+○  <20%
+◔  20–39%
+◑  40–59%
+◕  60–79%
+●  80–99%
+```
+
+The arc character, percentage, and absolute token counts are shown in `/status` and `/tokens`. When fill crosses 80 %, a one-time warning is printed suggesting the user run `/compact` to free context space.
+
 ## Banner
 
 The terminal banner is defined in `src/lmcode/ui/banner.py`. It renders block-letter ASCII art `LM─►CODE` using Unicode box-drawing characters, colored with Rich markup:


### PR DESCRIPTION
Updates README and docs/ to reflect v0.3.0. Closes #52.

- /compact, /tokens, /hide-model documented
- Cycling tips and context arc documented
- Slash command table updated
- Spinner keepalive pattern in architecture docs

Generated with Claude Code