### PR TITLE
feat: syntax-highlighted diff blocks for write_file tool results (#55)

### DIFF
--- a/src/lmcode/agent/core.py
+++ b/src/lmcode/agent/core.py
@@ -255,11 +255,11 @@ def _render_diff_sidebyside(
     # Backgrounds: Codex-style warm tints (confirmed closest to Claude Code post-v2.0.70).
     # Foreground: Catppuccin palette — softer than ODP, less harsh than pure red/green.
     # Equal bg: subtle violet-tinted neutral to keep the panel cohesive.
-    _EQ_BG = "#1c1a2e"    # unchanged lines — violet-tinted neutral
-    _DEL_FG = "#f38ba8"   # Catppuccin Mocha rose — warm, not harsh
-    _DEL_BG = "#4a221d"   # Codex dark-TC del bg — warm maroon (Claude Code style)
-    _ADD_FG = "#a6e3a1"   # Catppuccin Mocha green — soft, clearly "added"
-    _ADD_BG = "#1e3a2a"   # Codex dark-TC add bg — deep forest green
+    _EQ_BG = "#1c1a2e"  # unchanged lines — violet-tinted neutral
+    _DEL_FG = "#f38ba8"  # Catppuccin Mocha rose — warm, not harsh
+    _DEL_BG = "#4a221d"  # Codex dark-TC del bg — warm maroon (Claude Code style)
+    _ADD_FG = "#a6e3a1"  # Catppuccin Mocha green — soft, clearly "added"
+    _ADD_BG = "#1e3a2a"  # Codex dark-TC add bg — deep forest green
     _SEP = Text("│", style=f"dim {ACCENT}")
 
     table = Table(box=None, padding=(0, 1), show_header=False, expand=True)


### PR DESCRIPTION
## Summary

- `write_file` tool results now show a **side-by-side split diff** instead of a plain one-liner
- New files: syntax-highlighted panel (one-dark theme, line numbers)
- Modified files: side-by-side diff with `│` separator, +N/-N counter in title
- Colors sourced from Claude Code/Codex confirmed palette + Catppuccin Mocha:
  - Removed bg: `#4a221d` (Codex warm maroon), fg: `#f38ba8` (Catppuccin rose)
  - Added bg: `#1e3a2a` (Codex forest green), fg: `#a6e3a1` (Catppuccin green)
  - Equal lines bg: `#1c1a2e` (violet-tinted neutral)
- Old content captured before the write in `_wrap_tool_verbose` to enable real diffs

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)